### PR TITLE
support deserializing non public classes

### DIFF
--- a/yen/src/main/java/mono/KlaksonDeser.java
+++ b/yen/src/main/java/mono/KlaksonDeser.java
@@ -1,9 +1,6 @@
 package mono;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Parameter;
+import java.lang.reflect.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -12,7 +9,7 @@ import java.util.stream.Collectors;
 public class KlaksonDeser implements Deser {
     @Override
     public <T> T deser(String json, Class<T> clazz) {
-        return deserialize(json, clazz, 0,0).obj;
+        return deserialize(json, clazz, 0, 0).obj;
     }
 
     @Override
@@ -35,6 +32,7 @@ public class KlaksonDeser implements Deser {
         Object[] constructorParams = Arrays.stream(parameters).map(x -> fieldValuesByName.get(x.getName())).toArray();
 
         try {
+            constructor.setAccessible(true);
             return new DeserResult<>(fieldsDeserializationResult.charsRead, constructor.newInstance(constructorParams));
         } catch (InvocationTargetException | InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
@@ -122,7 +120,7 @@ public class KlaksonDeser implements Deser {
                     }
                 } else if (currentFieldType.isRecord()) {
                     // if field is a record deserialize it recursively - passing i-1 to begin from '{')
-                    var deserResult = deserialize(json, currentFieldType, i-1,level+1);
+                    var deserResult = deserialize(json, currentFieldType, i - 1, level + 1);
                     i += deserResult.charsRead() - 1;
                     result.put(currentFieldName, deserResult.obj);
                     sb.setLength(0);
@@ -145,7 +143,7 @@ public class KlaksonDeser implements Deser {
     }
 
     record FieldDeserialization(int charsRead, Map<String, Object> fields) {}
-    record DeserResult<T>(int charsRead, T obj){}
+    record DeserResult<T>(int charsRead, T obj) {}
 
 
     private Object parseValue(String rawFieldValue, Class<?> fieldType) {

--- a/yen/src/test/java/mono/klakson/DeserTest.java
+++ b/yen/src/test/java/mono/klakson/DeserTest.java
@@ -150,5 +150,23 @@ public class DeserTest {
         assertEquals(result, new MixedRecord(10, true, 2450L, 0.1d, 0.2f, "hello world"));
     }
 
+    @Test
+    public void deserializeNonPublicNestedClass() throws NoSuchFieldException {
+        var json = """
+                {
+                  "name": "Pavetta",
+                  "age": 22,
+                  "address": {
+                   "city": "Cintra",
+                   "street": "Rynkowa"
+                  }
+                }
+                """;
+
+        User result = deser.deser(json, User.class);
+
+        assertEquals(result.name(), User.withAddress("Pavetta", 22, "Cintra", "Rynkowa"));
+    }
+
 
 }

--- a/yen/src/test/java/mono/klakson/common/User.java
+++ b/yen/src/test/java/mono/klakson/common/User.java
@@ -1,0 +1,10 @@
+package mono.klakson.common;
+
+public record User (String name, int age, Address address) {
+    public static User withAddress(String name, int age, String city, String street) {
+        Address address1 = new Address(city, street);
+        return new User(name, age, address1);
+    }
+}
+
+record Address (String city, String street) {}


### PR DESCRIPTION
Deser would throw
`class mono.KlaksonDeser cannot access a member of class sample.Sample with modifiers ""`
For classes that are not public e.g.
```public record User (String name, int age, Address address) {
    public static User withAddress(String name, int age, String city, String street) {
        Address address1 = new Address(city, street);
        return new User(name, age, address1);
    }
}

record Address (String city, String street) {}
```
For Address class with default scope.
Solution for now will be to make constructor accessible. But we can think of some general rules for our DESER and maybe do not allow classes to be not public.